### PR TITLE
Disable dark theme for now

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,4 +21,7 @@ module.exports = {
     extend: {},
   },
   plugins: [require('daisyui')],
+  daisyui: {
+    themes: ['light'],
+  },
 };


### PR DESCRIPTION
DaisyUI sets dark theme based on system theme. Disabling the behaviour for now until we have the styles for dark mode ready.