### PR TITLE
Add SubjectConfirmationData to response

### DIFF
--- a/utils/response.ts
+++ b/utils/response.ts
@@ -108,6 +108,14 @@ const createResponseXML = async (params: {
             '@Format': 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
             '#text': user.email,
           },
+          'saml:SubjectConfirmation': {
+            '@Method': 'urn:oasis:names:tc:SAML:2.0:cm:bearer',
+            'saml:SubjectConfirmationData': {
+              '@InResponseTo': inResponseTo,
+              '@NotOnOrAfter': notAfter,
+              '@Recipient': acsUrl,
+            },
+          },
         },
         'saml:Conditions': {
           '@NotBefore': notBefore,


### PR DESCRIPTION
Firstly, thanks for creating a nice and simple tool for this purpose. 
We had been using it to test SAML login via AWS Cognito User Pools, however they have the following requirement -

![image](https://github.com/boxyhq/mock-saml/assets/73083832/5c0e822a-05a2-48f9-905a-af94dac697b4)
https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-saml-idp.html

This pull request adds an **SubjectConfirmation/SubjectConfirmationData** node to the response data that meets their requirements. I've tested the change locally and it is accepted by Cognito. 

I am relatively new to the SAML world so am unsure if this would create incompatibilities with other systems, I thought perhaps a checkbox configuration option on the login page would be a good way to make this (along with other features) optional, however I did not implement that.