### PR TITLE
Fix for audience extraction with some SPs 

### DIFF
--- a/utils/request.ts
+++ b/utils/request.ts
@@ -50,7 +50,7 @@ const extractSAMLRequestAttributes = async (rawRequest: string, isPost = true) =
     id: attributes.ID,
     acsUrl: attributes.AssertionConsumerServiceURL,
     providerName: attributes.ProviderName,
-    audience: issuer[0]['_'],
+    audience: issuer[0]['_'] ?? issuer[0],
     publicKey,
   };
 };


### PR DESCRIPTION
The SP audience value extraction [fails](https://github.com/boxyhq/mock-saml/issues/294) for some providers like KeyCloak. This change should fix the issue by using a fallback value.