### PR TITLE
chore: support VERCEL_PROJECT_PRODUCTION_URL

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,6 +1,6 @@
 import { fetchPrivateKey, fetchPublicKey } from 'utils';
 
-const appUrl = process.env.APP_URL || 'http://localhost:4000';
+const appUrl = process.env.APP_URL || `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` || 'http://localhost:4000';
 const entityId = process.env.ENTITY_ID || 'https://saml.example.com/entityid';
 const privateKey = fetchPrivateKey();
 const publicKey = fetchPublicKey();


### PR DESCRIPTION
Instructions to enable this in Vercel:-

```
[Automatically expose system environment variables](https://vercel.com/docs/environment-variables/system-environment-variables#automatically-expose-system-environment-variables)
To expose these environment variables to your deployments:

Navigate to your project on your [dashboard](https://vercel.com/dashboard).
Go to the Settings tab and click on the Environment Variables section.
Select the Automatically expose System Environment Variables checkbox.
```